### PR TITLE
chore: back-merge release v0.5.1 into develop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "i18next-turbo"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "i18next-turbo"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 
 [lib]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "i18next-turbo",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Blazing fast i18next translation key extractor - 10-100x faster with Rust + SWC",
   "license": "MIT",
   "author": "i18next-turbo contributors",
@@ -41,12 +41,12 @@
     "jiti": "^1.21.0"
   },
   "optionalDependencies": {
-    "i18next-turbo-darwin-arm64": "0.5.0",
-    "i18next-turbo-darwin-x64": "0.5.0",
-    "i18next-turbo-linux-arm64": "0.5.0",
-    "i18next-turbo-linux-x64": "0.5.0",
-    "i18next-turbo-win32-ia32": "0.5.0",
-    "i18next-turbo-win32-x64": "0.5.0"
+    "i18next-turbo-darwin-arm64": "0.5.1",
+    "i18next-turbo-darwin-x64": "0.5.1",
+    "i18next-turbo-linux-arm64": "0.5.1",
+    "i18next-turbo-linux-x64": "0.5.1",
+    "i18next-turbo-win32-ia32": "0.5.1",
+    "i18next-turbo-win32-x64": "0.5.1"
   },
   "engines": {
     "node": ">=14"


### PR DESCRIPTION
## Summary
- back-merge v0.5.1 release changes from main into develop
- keep version alignment after release tag

## Changes
- Cargo.toml version alignment
- Cargo.lock refresh
- package.json version alignment

## Validation
- already validated in release PR #50 CI
