### PR TITLE
docs: simplify README and move install details to docs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,525 +1,75 @@
-# i18next-turbo ⚡️
+# i18next-turbo
 
-**Rust + SWC で実現する超高速 i18next 翻訳キー抽出 — 10〜100 倍の速度**
+モダンな TypeScript/JavaScript コードベース向けの高速 i18next キー抽出ツールです。
 
-`i18next-turbo` は `i18next-parser` および `i18next-cli` の**超高速な代替**です。Rust と SWC で構築され、数千ファイルを**ミリ秒**で処理します。
+`i18next-turbo` は Rust + SWC ベースの抽出器で、i18next ワークフローとの互換性を重視して設計されています。CI の高速化と、開発時の低遅延な watch 実行を目的としています。
 
-> **⚠️ 開発中**: 現在は Rust バイナリとして利用可能です。npm パッケージの配布は準備中です。
-
----
-
-## 🚀 なぜ i18next-turbo か
-
-### パフォーマンス比較
-
-| ツール | エンジン | 処理時間（1k ファイル） | Watch モード |
-|:---|:---|:---|:---|
-| `i18next-parser` | Node.js (Babel/Regex) | **10〜30 秒** | 遅い / 高 CPU |
-| `i18next-cli` | Node.js (SWC) | **2〜5 秒** | 中程度 |
-| **`i18next-turbo`** | **Rust + SWC** | **< 100ms** ⚡️ | **即時 / 低負荷** |
-
-**ベンチマーク結果（MacBook Pro M3、1,000 ファイル）:**
-```
-i18next-parser:  ████████████████████ 12.5s
-i18next-cli:     ████████ 2.3s
-i18next-turbo:   ▏ 0.08s ⚡️ (約150倍高速)
-```
-
-### 主な特徴
-
-- ⚡️ **超高速**: 大規模プロジェクトでも即座に処理
-- 🎯 **高精度**: SWC による完全な AST 解析で誤検出ゼロ
-- 🔄 **リアルタイム更新**: Watch モードで保存と同時に JSON を更新
-- 🛡️ **翻訳を保持**: 新キーを追加しても既存の翻訳には触れない
-- 📦 **軽量**: 低メモリ、バックグラウンド実行に適している
-- 🔧 **i18next 互換**: 名前空間、複数形、コンテキストなどをサポート
-
----
-
-## ✨ 実装済み機能
-
-### 基本的な抽出パターン
-
-```typescript
-// ✅ サポート済み
-t('hello.world')
-i18n.t('greeting')
-t('common:button.save')  // 名前空間付き
-```
-
-### React コンポーネント
-
-```tsx
-// ✅ Trans コンポーネント
-<Trans i18nKey="welcome">Welcome</Trans>
-<Trans i18nKey="common:greeting" defaults="Hello!" />
-```
-
-### 複数形とコンテキスト
-
-```typescript
-// ✅ 複数形
-t('apple', { count: 5 })  // → apple_one, apple_other
-
-// ✅ コンテキスト
-t('friend', { context: 'male' })  // → friend_male
-
-// ✅ 複数形 + コンテキスト
-t('friend', { count: 2, context: 'female' })  // → friend_female_one, friend_female_other
-```
-
-ICU の複数形ルールに従い、`locales` に列挙した各言語に必要なカテゴリ（`zero`、`one`、`few`、`many` など）を生成します。例えばロシア語を指定すると `friend_one`、`friend_few`、`friend_many`、`friend_other` が一括で追加されます。
-
-### その他の機能
-
-- ✅ **マジックコメント**: `// i18next-extract-disable-line`
-- ✅ **ネストキー**: `button.submit` → `{"button": {"submit": ""}}`
-- ✅ **キー自動ソート**: 一貫した JSON のためアルファベット順にソート
-- ✅ **TypeScript 型生成**: オートコンプリートと型安全性
-- ✅ **デッドキー検出**: リファクタ後に未使用キーを検出
-
----
-
-## 📦 インストール
-
-### 方法 1: Cargo でインストール（推奨）
+## インストール
 
 ```bash
-cargo install i18next-turbo
+npm install --save-dev i18next-turbo
 ```
 
-### 方法 2: ソースからビルド
+パッケージ本体は `optionalDependencies` を使って OS/アーキテクチャ別バイナリを解決します。
+詳細（対応表、フォールバック、トラブル対応）は [docs/installation.ja.md](docs/installation.ja.md) を参照してください。
+
+## クイックスタート
+
+1. 設定ファイルを初期化:
 
 ```bash
-git clone https://github.com/your-username/i18next-turbo.git
-cd i18next-turbo
-cargo build --release
-# バイナリは target/release/i18next-turbo に生成されます
+i18next-turbo init
 ```
 
-> **📌 注意**: npm パッケージの配布は準備中です。Node.js プロジェクトでは現時点で Rust のインストールが必要です。
-
----
-
-## 🛠️ 使い方
-
-### 1. 設定ファイルの作成
-
-プロジェクトルートに `i18next-turbo.json` を作成します:
-
-```json
-{
-  "input": ["src/**/*.{ts,tsx,js,jsx}"],
-  "output": "locales/$LOCALE/$NAMESPACE.json",
-  "locales": ["en", "ja", "de"],
-  "defaultNamespace": "translation",
-  "functions": ["t", "i18n.t"],
-  "types": {
-    "output": "src/@types/i18next.d.ts",
-    "defaultLocale": "en",
-    "localesDir": "locales"
-  }
-}
-```
-
-#### 設定オプション
-
-| オプション | 説明 | デフォルト |
-|:---|:---|:---|
-| `input` | 抽出対象のファイルパターン（glob） | `["src/**/*.{ts,tsx,js,jsx}"]` |
-| `output` | 出力パス（`$LOCALE` と `$NAMESPACE` が置換される） | `"locales"` |
-| `locales` | 対象言語のリスト | `["en"]` |
-| `defaultNamespace` | デフォルト名前空間 | `"translation"` |
-| `functions` | 抽出対象の関数名 | `["t"]` |
-| `logLevel` | ログの詳細度（`error`/`warn`/`info`/`debug`） | `"info"` |
-| `types.output` | 生成する TypeScript 型定義のパス | `"src/@types/i18next.d.ts"` |
-| `types.defaultLocale` | 型生成時のデフォルトロケール | `locales` の先頭 |
-| `types.localesDir` | 型生成時に読み込むディレクトリ | `output` と同じ |
-| `types.input` | 型生成に含めるロケールファイルの glob パターン | デフォルトロケール配下の全 `*.json` |
-| `types.resourcesFile` | `Resources` インターフェース用のオプションの補助ファイルパス | 生成しない |
-| `types.enableSelector` | セレクター用ヘルパー型を有効化（`true`、`false`、`"optimize"`） | `false` |
-| `types.indentation` | 生成する型ファイルのインデント | `2 スペース` |
-| `defaultValue` | 文字列または関数 `(key, namespace, language, value) => string` | `""` |
-| `sort` | 真偽値または関数 `(a, b) => number` | `true` |
-| `plugins` | プラグイン配列（`setup` / `onLoad` / `onVisitNode` / `onEnd` / `afterSync`） | `[]` |
-
-オプションの `types` ブロックで、型定義の出力先と、`i18next-turbo typegen` または `i18next-turbo extract --generate-types` が参照するロケールファイルを制御できます。
-
-> CLI は `i18next-turbo.json`、`i18next-parser.config.(js|ts)`、`i18next.config.(js|ts)` を自動で検索します（CommonJS / ESM / TypeScript は `jiti` 経由）。`--config path/to/i18next.config.ts` で直接指定することもできます。
-
-### 2. キーの抽出
-
-1 回だけ実行する場合（CI/CD など）:
+2. 1 回だけ抽出:
 
 ```bash
 i18next-turbo extract
 ```
 
-#### 出力例
-
-```
-=== i18next-turbo extract ===
-
-Configuration:
-  Input patterns: ["src/**/*.{ts,tsx}"]
-  Output: locales
-  Locales: ["en", "ja"]
-  Functions: ["t"]
-
-Extracted keys by file:
-------------------------------------------------------------
-
-src/components/Button.tsx
-  - button.submit
-  - button.cancel
-
-src/pages/Home.tsx
-  - welcome.title
-  - welcome.message
-
-------------------------------------------------------------
-
-Extraction Summary:
-  Files processed: 2
-  Unique keys found: 4
-
-Syncing to locale files...
-  locales/en/translation.json - added 4 new key(s)
-
-Done!
-```
-
-### 3. Watch モード（開発時）
-
-ファイル保存時に自動でキーを抽出・更新します:
+3. 開発中は watch 実行:
 
 ```bash
 i18next-turbo watch
 ```
 
-#### 動作例
+## 最小設定
 
-```
-=== i18next-turbo watch ===
-
-Watching: src
-Watching for changes... (Ctrl+C to stop)
-
---- Change detected ---
-  Modified: src/components/Button.tsx
-  Added 1 new key(s)
---- Sync complete ---
-```
-
-開発中はこのコマンドをバックグラウンドで実行すると、翻訳キーを追加するたびに JSON が自動で更新されます。
-
-### 4. 翻訳状況
-
-特定ロケールの翻訳進捗を確認します:
-
-```bash
-i18next-turbo status --locale ja
-```
-
-主なフラグ:
-
-- `--namespace <name>`: レポートを単一の名前空間に限定
-- `--fail-on-incomplete`: 不足キーやデッドキーがある場合に非ゼロで終了（CI 向け）
-
-サマリにはテキストのプログレスバーが含まれ、選択したロケール/名前空間の完了度をすぐに把握できます。
-
----
-
-## 📝 使用例
-
-### 基本的な使い方
-
-```typescript
-// src/components/Button.tsx
-import { useTranslation } from 'react-i18next';
-
-function Button() {
-  const { t } = useTranslation();
-  
-  return (
-    <button>
-      {t('button.submit')}
-    </button>
-  );
-}
-```
-
-実行後、`locales/en/translation.json` には次のように追加されます:
+プロジェクトルートに `i18next-turbo.json` を作成:
 
 ```json
 {
-  "button": {
-    "submit": ""
-  }
+  "input": ["src/**/*.{ts,tsx,js,jsx}"],
+  "output": "locales/$LOCALE/$NAMESPACE.json",
+  "locales": ["en", "ja"],
+  "defaultNamespace": "translation",
+  "functions": ["t", "i18n.t"]
 }
 ```
 
-### 名前空間の使用
-
-```typescript
-// 名前空間を指定
-t('common:button.save')  // → locales/en/common.json に保存
-```
-
-### React Trans コンポーネント
-
-```tsx
-import { Trans } from 'react-i18next';
-
-function Welcome() {
-  return (
-    <Trans i18nKey="welcome.title" defaults="Welcome!">
-      Welcome to our app!
-    </Trans>
-  );
-}
-```
-
-### 複数形の使用
-
-```typescript
-const count = 5;
-t('apple', { count });  // → apple_one, apple_other を生成
-```
-
-生成される JSON:
-
-```json
-{
-  "apple_one": "",
-  "apple_other": ""
-}
-```
-
----
-
-## 🎯 i18next-parser からの移行
-
-`i18next-parser` を使っている場合、設定を少し変えるだけで移行できます。
-
-### 設定の違い
-
-| i18next-parser | i18next-turbo |
-|:---|:---|
-| `input` | `input`（同じ） |
-| `output` | `output`（同じ） |
-| `locales` | `locales`（同じ） |
-| `defaultNamespace` | `defaultNamespace`（同じ） |
-| `functions` | `functions`（同じ） |
-
-基本的に同じ設定がそのまま使えます。
-
-### 移行手順
-
-1. `i18next-turbo.json` を作成（既存の設定をコピー）
-2. `i18next-turbo extract` を実行
-3. 生成された JSON を確認
-4. Watch モードで開発を開始
-
-### i18next-cli 設定との互換性
-
-`i18next-turbo` は `i18next-cli` の設定ファイルを読み、`extract` オプションの一部をマッピングできます。
-
-対応しているマッピング:
-
-| i18next-cli (extract) | i18next-turbo |
-|:---|:---|
-| `input` | `input` |
-| `output`（文字列） | `output`（ディレクトリ） |
-| `output`（関数） | 評価して `output` ディレクトリに射影 |
-| `functions` | `functions` |
-| `defaultNS` | `defaultNamespace` |
-| `keySeparator` | `keySeparator`（`false` → 空文字） |
-| `nsSeparator` | `nsSeparator`（`false` → 空文字） |
-| `contextSeparator` | `contextSeparator` |
-| `pluralSeparator` | `pluralSeparator` |
-| `defaultNS = false` | `defaultNamespace = ""` と名前空間なしモード |
-| `secondaryLanguages` | `secondaryLanguages` |
-| `transKeepBasicHtmlNodesFor` | `transKeepBasicHtmlNodesFor` |
-| `preserveContextVariants` | `preserveContextVariants` |
-| `interpolationPrefix` / `interpolationSuffix` | `interpolationPrefix` / `interpolationSuffix` |
-| `mergeNamespaces` | `mergeNamespaces` |
-| `extractFromComments` | `extractFromComments`（デフォルト `true`） |
-
-関数形式サポート:
-
-| i18next-cli (extract) | i18next-turbo の動作 |
-|:---|:---|
-| `defaultValue` 関数 | `extract` / `sync` 後にロケールファイルへ適用 |
-| `sort` 関数 | `extract` / `sync` 後にキー順を再構築 |
-
-補足:
-- `locales/{{language}}/{{namespace}}.json` のような出力テンプレートはベースディレクトリに集約されます。
-- `defaultValue` / `sort` の関数形式は現在 `json` 出力に適用されます（`json5` はスキップ）。
-
----
-
-## 🔧 高度な機能
-
-### マジックコメント
-
-特定行を抽出対象から除外します:
-
-```typescript
-// i18next-extract-disable-line
-const dynamicKey = `user.${role}.permission`;
-t(dynamicKey);  // この行は抽出されません
-```
-
-### プラグインフック（Node ラッパー）
-
-`plugins` にモジュールパスまたはオブジェクトを設定できます。現在のフック:
-
-- `setup(context)`: コマンド開始時
-- `onLoad({ filePath, relativePath, source, ... })`: 抽出前のファイル前処理（返り値で文字列を返すと差し替え）
-- `onVisitNode(node)`: ノード訪問イベント
-  - `extract/watch/status/check/lint` では Rust 側の AST 訪問イベント（JSON Lines 中継）
-  - `sync` ではロケール JSON 走査イベント
-- `onEnd(context)`: コマンド完了時
-- `afterSync(context)`: 同期処理後
-
-例:
-
-```js
-module.exports = {
-  onLoad({ source }) {
-    return source.replace(/__\(([^)]+)\)/g, "t('$1')");
-  },
-  onVisitNode(node) {
-    if (node.type === 'TranslationKey' && node.key && node.key.endsWith('.tmp')) {
-      console.warn(`temporary key detected: ${node.key}`);
-    }
-  }
-};
-```
-
-ドキュメント:
-- [API](./docs/api.ja.md)
-- [使用例](./docs/usage-examples.ja.md)
-- [マイグレーションガイド](./docs/migration-guide.ja.md)
-- [トラブルシューティング](./docs/troubleshooting.ja.md)
-- [パフォーマンステスト](./docs/performance-testing.ja.md)
-
-### TypeScript 型生成
-
-```bash
-# 設定に基づいて 1 回だけ型定義を生成（オプションの `types` ブロックを参照）
-i18next-turbo typegen
-
-# または抽出と型生成を同時に実行
-i18next-turbo extract --generate-types
-```
-
-生成される型定義の例:
-
-```typescript
-interface Translation {
-  button: {
-    submit: string;
-    cancel: string;
-  };
-  welcome: {
-    title: string;
-    message: string;
-  };
-}
-```
-
-### デッドキー検出
-
-```bash
-# 将来 i18next-turbo cleanup コマンドとして提供予定
-# コード内で見つからないキーを検出
-```
-
----
-
-## 📊 パフォーマンス
-
-### ベンチマーク結果
-
-| ファイル数 | i18next-parser | i18next-cli | i18next-turbo |
-|:---|:---:|:---:|:---:|
-| 100 | 1.2s | 0.3s | **0.01s** |
-| 1,000 | 12.5s | 2.3s | **0.08s** |
-| 10,000 | 125s | 23s | **0.8s** |
-
-### メモリ使用量
-
-- **i18next-parser**: 約 200MB
-- **i18next-cli**: 約 150MB
-- **i18next-turbo**: **約 50MB**（約 4 倍軽量）
-
----
-
-## 🗺️ ロードマップ
-
-### ✅ 実装済み
-
-- [x] 基本的な `t()` 関数の抽出
-- [x] `<Trans>` コンポーネント対応
-- [x] 名前空間対応
-- [x] 複数形（基本の `_one`、`_other`）
-- [x] コンテキスト対応
-- [x] Watch モード
-- [x] JSON 同期（既存翻訳の保持）
-- [x] TypeScript 型生成
-- [x] デッドキー検出
-
-### 🚧 開発中
-
-- [x] npm パッケージの配布
-- [x] `useTranslation` フックの完全対応（`keyPrefix` など）
-- [x] 言語別複数形カテゴリ（`zero`、`few`、`many` など）
-- [x] JS/TS 設定ファイルの読み込み
-
-### 📅 予定
-
-- [ ] Locize 統合
-
-詳細は [TODO.md](./TODO.md) を参照してください。
-
----
-
-## 🤝 コントリビュート
-
-プルリクエストと Issue の報告を歓迎します。
-
-1. このリポジトリをフォーク
-2. フィーチャーブランチを作成（`git checkout -b feature/amazing-feature`）
-3. 変更をコミット（`git commit -m 'Add some amazing feature'）
-4. ブランチにプッシュ（`git push origin feature/amazing-feature`）
-5. プルリクエストを開く
-
-行動規範の詳細は [CONTRIBUTING.md](./CONTRIBUTING.md) を参照してください。
-
----
-
-## 📄 ライセンス
-
-MIT License。詳細は [LICENSE](./LICENSE) を参照してください。
-
----
-
-## 🙏 謝辞
-
-- [i18next](https://www.i18next.com/) — 優れた国際化フレームワーク
-- [SWC](https://swc.rs/) — 高速な JavaScript/TypeScript コンパイラ
-- [i18next-parser](https://github.com/i18next/i18next-parser) — インスピレーションの源
-
----
-
-## ⚠️ 免責事項
-
-- 本ツールは **i18next の非公式ツール**です
-- API はメジャーバージョン間で変更される可能性があります
-- npm パッケージ公開済み: [i18next-turbo](https://www.npmjs.com/package/i18next-turbo)
-
----
-
-**質問や問題は [Issue](https://github.com/your-username/i18next-turbo/issues) でお知らせください。**
+## CLI コマンド
+
+- `extract`: キー抽出とロケール同期
+- `watch`: 変更監視しながら継続同期
+- `sync`: 抽出結果から同期のみ実行
+- `check`: 未使用キー検出/削除
+- `lint`: ハードコード文字列検出
+- `status`: 翻訳進捗表示
+- `typegen`: TypeScript 型生成
+- `rename-key`: 翻訳キーの安全なリネーム
+- `migrate-config`: i18next-parser 形式設定の移行
+
+## ドキュメント
+
+- [インストールとバイナリ解決](docs/installation.ja.md)
+- [API リファレンス](docs/api.ja.md)
+- [移行ガイド](docs/migration-guide.ja.md)
+- [トラブルシューティング](docs/troubleshooting.ja.md)
+- [使用例](docs/usage-examples.ja.md)
+- [パフォーマンステスト](docs/performance-testing.ja.md)
+
+## コントリビュート
+
+- [Contributing Guide](CONTRIBUTING.md)
+- [Code of Conduct](CODE_OF_CONDUCT.md)
+- [Security Policy](SECURITY.md)

--- a/README.md
+++ b/README.md
@@ -1,109 +1,39 @@
-# i18next-turbo ⚡️
+# i18next-turbo
 
-**Blazing fast i18next translation key extractor - 10-100x faster with Rust + SWC**
+Fast i18next key extraction for modern TypeScript/JavaScript codebases.
 
-`i18next-turbo` is a **blazing fast replacement** for `i18next-parser` and `i18next-cli`. Built with Rust and SWC, it processes thousands of files in **milliseconds**.
+`i18next-turbo` is a Rust + SWC based extractor compatible with i18next-style workflows. It is designed for fast CI runs and low-latency watch mode.
 
-> **⚠️ Under Development**: Currently available as a Rust binary. npm package distribution is in preparation.
-
----
-
-## 🚀 Why i18next-turbo?
-
-### Performance Comparison
-
-| Tool | Engine | Processing Time (1k files) | Watch Mode |
-|:---|:---|:---|:---|
-| `i18next-parser` | Node.js (Babel/Regex) | **10-30s** | Slow / High CPU |
-| `i18next-cli` | Node.js (SWC) | **2-5s** | Moderate |
-| **`i18next-turbo`** | **Rust + SWC** | **< 100ms** ⚡️ | **Instant / Low footprint** |
-
-**Benchmark Results (MacBook Pro M3, 1,000 files):**
-```
-i18next-parser:  ████████████████████ 12.5s
-i18next-cli:     ████████ 2.3s
-i18next-turbo:   ▏ 0.08s ⚡️ (~150x faster)
-```
-
-### Key Features
-
-- ⚡️ **Blazing Fast**: Instant processing even for large projects
-- 🎯 **High Accuracy**: Full AST parsing with SWC for zero false positives
-- 🔄 **Real-time Updates**: Watch mode updates JSON files the moment you save
-- 🛡️ **Preserves Translations**: New keys are added without touching existing translations
-- 📦 **Lightweight**: Low memory usage, comfortable background execution
-- 🔧 **i18next Compatible**: Supports namespaces, plurals, context, and more
-
----
-
-## ✨ Implemented Features
-
-### Basic Extraction Patterns
-
-```typescript
-// ✅ Supported
-t('hello.world')
-i18n.t('greeting')
-t('common:button.save')  // With namespace
-```
-
-### React Components
-
-```tsx
-// ✅ Trans component
-<Trans i18nKey="welcome">Welcome</Trans>
-<Trans i18nKey="common:greeting" defaults="Hello!" />
-```
-
-### Plurals and Context
-
-```typescript
-// ✅ Plurals
-t('apple', { count: 5 })  // → apple_one, apple_other
-
-// ✅ Context
-t('friend', { context: 'male' })  // → friend_male
-
-// ✅ Plurals + Context
-t('friend', { count: 2, context: 'female' })  // → friend_female_one, friend_female_other
-```
-
-Based on ICU plural rules, the required categories (`zero`, `one`, `few`, `many`, etc.) are generated for each language in `locales`. For example, with Russian you get `friend_one`, `friend_few`, `friend_many`, `friend_other` added at once.
-
-### Other Features
-
-- ✅ **Magic Comments**: `// i18next-extract-disable-line`
-- ✅ **Nested Keys**: `button.submit` → `{"button": {"submit": ""}}`
-- ✅ **Auto-sorted Keys**: Alphabetically sorted for consistent JSON
-- ✅ **TypeScript Type Generation**: Autocomplete and type safety
-- ✅ **Dead Key Detection**: Find unused keys after refactoring
-
----
-
-## 📦 Installation
-
-### Method 1: Install via Cargo (Recommended)
+## Install
 
 ```bash
-cargo install i18next-turbo
+npm install --save-dev i18next-turbo
 ```
 
-### Method 2: Build from Source
+The package resolves a platform-specific binary through `optionalDependencies`.
+For details (platform mapping, fallback behavior, troubleshooting), see [docs/installation.md](docs/installation.md).
+
+## Quick Start
+
+1. Initialize config:
 
 ```bash
-git clone https://github.com/your-username/i18next-turbo.git
-cd i18next-turbo
-cargo build --release
-# Binary will be generated at target/release/i18next-turbo
+i18next-turbo init
 ```
 
-> **📌 Note**: npm package distribution is in preparation. For Node.js projects, Rust installation is currently required.
+2. Extract keys once:
 
----
+```bash
+i18next-turbo extract
+```
 
-## 🛠️ Usage
+3. Run watch mode during development:
 
-### 1. Create Configuration File
+```bash
+i18next-turbo watch
+```
+
+## Minimal Config
 
 Create `i18next-turbo.json` in your project root:
 
@@ -111,395 +41,35 @@ Create `i18next-turbo.json` in your project root:
 {
   "input": ["src/**/*.{ts,tsx,js,jsx}"],
   "output": "locales/$LOCALE/$NAMESPACE.json",
-  "locales": ["en", "ja", "de"],
+  "locales": ["en", "ja"],
   "defaultNamespace": "translation",
-  "functions": ["t", "i18n.t"],
-  "types": {
-    "output": "src/@types/i18next.d.ts",
-    "defaultLocale": "en",
-    "localesDir": "locales"
-  }
+  "functions": ["t", "i18n.t"]
 }
 ```
 
-#### Configuration Options
-
-| Option | Description | Default |
-|:---|:---|:---|
-| `input` | File patterns to extract (glob) | `["src/**/*.{ts,tsx,js,jsx}"]` |
-| `output` | Output path (`$LOCALE` and `$NAMESPACE` are replaced) | `"locales"` |
-| `locales` | List of target languages | `["en"]` |
-| `defaultNamespace` | Default namespace | `"translation"` |
-| `functions` | Function names to extract | `["t"]` |
-| `logLevel` | Logging verbosity (`error`/`warn`/`info`/`debug`) | `"info"` |
-| `types.output` | Path for generated TypeScript definitions | `"src/@types/i18next.d.ts"` |
-| `types.defaultLocale` | Default locale for type generation | First entry in `locales` |
-| `types.localesDir` | Directory read when generating types | Same as `output` |
-| `types.input` | Glob patterns of locale files to include in type generation | all `*.json` in default locale |
-| `types.resourcesFile` | Optional secondary file path for `Resources` interfaces | not generated |
-| `types.enableSelector` | Enable selector helper types (`true`, `false`, `"optimize"`) | `false` |
-| `types.indentation` | Indentation for generated type files | `2 spaces` |
-| `defaultValue` | String or function `(key, namespace, language, value) => string` | `""` |
-| `sort` | Boolean or function `(a, b) => number` for locale key ordering | `true` |
-| `plugins` | Plugin modules/objects with `setup`/`onEnd`/`afterSync` hooks | `[]` |
-
-Use the optional `types` block to control where type definitions are written and which locale files `i18next-turbo typegen` or `i18next-turbo extract --generate-types` should use.
-
-> The CLI automatically searches for `i18next-turbo.json`, `i18next-parser.config.(js|ts)`, and `i18next.config.(js|ts)` (CommonJS, ESM, or TypeScript via `jiti`). You can also pass `--config path/to/i18next.config.ts` directly.
-
-### 2. Extract Keys
-
-Run once (e.g., for CI/CD):
-
-```bash
-i18next-turbo extract
-```
-
-#### Example Output
-
-```
-=== i18next-turbo extract ===
-
-Configuration:
-  Input patterns: ["src/**/*.{ts,tsx}"]
-  Output: locales
-  Locales: ["en", "ja"]
-  Functions: ["t"]
-
-Extracted keys by file:
-------------------------------------------------------------
-
-src/components/Button.tsx
-  - button.submit
-  - button.cancel
-
-src/pages/Home.tsx
-  - welcome.title
-  - welcome.message
-
-------------------------------------------------------------
-
-Extraction Summary:
-  Files processed: 2
-  Unique keys found: 4
-
-Syncing to locale files...
-  locales/en/translation.json - added 4 new key(s)
-
-Done!
-```
-
-### 3. Watch Mode (Development)
-
-Automatically extract and update keys on file save:
-
-```bash
-i18next-turbo watch
-```
-
-#### Example Behavior
-
-```
-=== i18next-turbo watch ===
-
-Watching: src
-Watching for changes... (Ctrl+C to stop)
-
---- Change detected ---
-  Modified: src/components/Button.tsx
-  Added 1 new key(s)
---- Sync complete ---
-```
-
-Run this command in the background during development to automatically update JSON files when you add translation keys.
-
-### 4. Translation Status
-
-Check translation progress for a specific locale:
-
-```bash
-i18next-turbo status --locale ja
-```
-
-Useful flags:
-
-- `--namespace <name>`: limit the report to a single namespace
-- `--fail-on-incomplete`: exit with a non-zero status when missing or dead keys are found (great for CI)
-
-The summary includes a textual progress bar so you can instantly gauge completion status for the selected locale/namespace.
-
----
-
-## 📝 Examples
-
-### Basic Usage
-
-```typescript
-// src/components/Button.tsx
-import { useTranslation } from 'react-i18next';
-
-function Button() {
-  const { t } = useTranslation();
-  
-  return (
-    <button>
-      {t('button.submit')}
-    </button>
-  );
-}
-```
-
-After running, `locales/en/translation.json` will have:
-
-```json
-{
-  "button": {
-    "submit": ""
-  }
-}
-```
-
-### Using Namespaces
-
-```typescript
-// Specify namespace
-t('common:button.save')  // → Saved to locales/en/common.json
-```
-
-### React Trans Component
-
-```tsx
-import { Trans } from 'react-i18next';
-
-function Welcome() {
-  return (
-    <Trans i18nKey="welcome.title" defaults="Welcome!">
-      Welcome to our app!
-    </Trans>
-  );
-}
-```
-
-### Using Plurals
-
-```typescript
-const count = 5;
-t('apple', { count });  // → Generates apple_one, apple_other
-```
-
-Generated JSON:
-
-```json
-{
-  "apple_one": "",
-  "apple_other": ""
-}
-```
-
----
-
-## 🎯 Migration from i18next-parser
-
-If you're using `i18next-parser`, you can migrate with minimal changes to your configuration.
-
-### Configuration Differences
-
-| i18next-parser | i18next-turbo |
-|:---|:---|
-| `input` | `input` (same) |
-| `output` | `output` (same) |
-| `locales` | `locales` (same) |
-| `defaultNamespace` | `defaultNamespace` (same) |
-| `functions` | `functions` (same) |
-
-Basically the same configuration works!
-
-### Migration Steps
-
-1. Create `i18next-turbo.json` (copy your existing config)
-2. Run `i18next-turbo extract`
-3. Verify generated JSON files
-4. Start development with watch mode
-
-### i18next-cli Config Compatibility
-
-`i18next-turbo` can read `i18next-cli` config files and map a subset of `extract` options.
-
-Supported mappings:
-
-| i18next-cli (extract) | i18next-turbo |
-|:---|:---|
-| `input` | `input` |
-| `output` (string) | `output` (directory) |
-| `output` (function) | evaluated and projected to `output` directory |
-| `functions` | `functions` |
-| `defaultNS` | `defaultNamespace` |
-| `keySeparator` | `keySeparator` (`false` -> empty string) |
-| `nsSeparator` | `nsSeparator` (`false` -> empty string) |
-| `contextSeparator` | `contextSeparator` |
-| `pluralSeparator` | `pluralSeparator` |
-| `defaultNS = false` | `defaultNamespace = ""` + namespace-less mode |
-| `secondaryLanguages` | `secondaryLanguages` |
-| `transKeepBasicHtmlNodesFor` | `transKeepBasicHtmlNodesFor` |
-| `preserveContextVariants` | `preserveContextVariants` |
-| `interpolationPrefix` / `interpolationSuffix` | `interpolationPrefix` / `interpolationSuffix` |
-| `mergeNamespaces` | `mergeNamespaces` |
-| `extractFromComments` | `extractFromComments` (default `true`) |
-
-Function-form support:
-
-| i18next-cli (extract) | i18next-turbo behavior |
-|:---|:---|
-| `defaultValue` function | Applied after `extract`/`sync` on generated locale files |
-| `sort` function | Applied after `extract`/`sync` to order keys |
-
-Plugin support:
-
-| Hook | Status |
-|:---|:---|
-| `setup` | Supported |
-| `onEnd` | Supported |
-| `afterSync` | Supported |
-
-Notes:
-- Output templates like `locales/{{language}}/{{namespace}}.json` are reduced to a base directory.
-
-Documentation:
-- [API](./docs/api.md)
-- [Usage examples](./docs/usage-examples.md)
-- [Migration guide](./docs/migration-guide.md)
-- [Troubleshooting](./docs/troubleshooting.md)
-- [Performance testing](./docs/performance-testing.md)
-
----
-
-## 🔧 Advanced Features
-
-### Magic Comments
-
-Exclude specific lines from extraction:
-
-```typescript
-// i18next-extract-disable-line
-const dynamicKey = `user.${role}.permission`;
-t(dynamicKey);  // This line won't be extracted
-```
-
-### TypeScript Type Generation
-
-```bash
-# Generate once based on your config (honors the optional `types` block)
-i18next-turbo typegen
-
-# Or run extraction and type generation together
-i18next-turbo extract --generate-types
-```
-
-Example generated type definitions:
-
-```typescript
-interface Translation {
-  button: {
-    submit: string;
-    cancel: string;
-  };
-  welcome: {
-    title: string;
-    message: string;
-  };
-}
-```
-
-### Dead Key Detection
-
-```bash
-# Will be available as i18next-turbo cleanup command in the future
-# Detects keys not found in code
-```
-
----
-
-## 📊 Performance
-
-### Benchmark Results
-
-| Files | i18next-parser | i18next-cli | i18next-turbo |
-|:---|:---:|:---:|:---:|
-| 100 | 1.2s | 0.3s | **0.01s** |
-| 1,000 | 12.5s | 2.3s | **0.08s** |
-| 10,000 | 125s | 23s | **0.8s** |
-
-### Memory Usage
-
-- **i18next-parser**: ~200MB
-- **i18next-cli**: ~150MB
-- **i18next-turbo**: **~50MB** (~4x lighter)
-
----
-
-## 🗺️ Roadmap
-
-### ✅ Implemented
-
-- [x] Basic `t()` function extraction
-- [x] `<Trans>` component support
-- [x] Namespace support
-- [x] Plurals (basic `_one`, `_other`)
-- [x] Context support
-- [x] Watch mode
-- [x] JSON synchronization (preserves existing translations)
-- [x] TypeScript type generation
-- [x] Dead key detection
-
-### 🚧 In Development
-
-- [x] npm package distribution
-- [x] Full `useTranslation` hook support (`keyPrefix`, etc.)
-- [x] Language-specific plural categories (`zero`, `few`, `many`, etc.)
-- [x] JS/TS config file loading
-
-### 📅 Planned
-
-- [ ] Locize integration
-
-See [TODO.md](./TODO.md) for details.
-
----
-
-## 🤝 Contributing
-
-Pull requests and issue reports are welcome!
-
-1. Fork this repository
-2. Create a feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add some amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
-
-Please read [CONTRIBUTING.md](./CONTRIBUTING.md) for details on our code of conduct.
-
----
-
-## 📄 License
-
-MIT License - see [LICENSE](./LICENSE) file for details.
-
----
-
-## 🙏 Acknowledgments
-
-- [i18next](https://www.i18next.com/) - Amazing internationalization framework
-- [SWC](https://swc.rs/) - Fast JavaScript/TypeScript compiler
-- [i18next-parser](https://github.com/i18next/i18next-parser) - Source of inspiration
-
----
-
-## ⚠️ Disclaimer
-
-- This tool is an **unofficial i18next tool**
-- APIs may evolve between major versions
-- npm package is available: [i18next-turbo](https://www.npmjs.com/package/i18next-turbo)
-
----
-
-**Questions or issues? Please open an [Issue](https://github.com/your-username/i18next-turbo/issues)!**
+## CLI Commands
+
+- `extract`: extract keys and sync locale files
+- `watch`: watch files and sync continuously
+- `sync`: sync from extracted cache/results
+- `check`: detect/remove dead keys
+- `lint`: detect hardcoded user-facing strings
+- `status`: show translation progress
+- `typegen`: generate TypeScript resource types
+- `rename-key`: rename translation keys safely
+- `migrate-config`: migrate config from i18next-parser style
+
+## Docs
+
+- [Installation and Binary Resolution](docs/installation.md)
+- [API Reference](docs/api.md)
+- [Migration Guide](docs/migration-guide.md)
+- [Troubleshooting](docs/troubleshooting.md)
+- [Usage Examples](docs/usage-examples.md)
+- [Performance Testing](docs/performance-testing.md)
+
+## Contributing
+
+- [Contributing Guide](CONTRIBUTING.md)
+- [Code of Conduct](CODE_OF_CONDUCT.md)
+- [Security Policy](SECURITY.md)

--- a/docs/installation.ja.md
+++ b/docs/installation.ja.md
@@ -1,0 +1,57 @@
+# インストールとバイナリ解決
+
+## 推奨インストール
+
+```bash
+npm install --save-dev i18next-turbo
+```
+
+`i18next-turbo` は `optionalDependencies` を使って OS 別パッケージを解決します。
+`bin/cli.js` は次の順で実行バイナリを探索します。
+
+1. `CARGO_BIN_EXE_i18next_turbo`（Cargo テスト/開発環境）
+2. `I18NEXT_TURBO_BINARY`（手動上書き）
+3. ローカルビルド（`target/debug`, `target/release`）
+4. インストール済み OS 別パッケージ
+
+## OS 別パッケージ
+
+- `i18next-turbo-darwin-arm64`
+- `i18next-turbo-darwin-x64`
+- `i18next-turbo-linux-x64-gnu`
+- `i18next-turbo-linux-x64-musl`
+- `i18next-turbo-win32-x64-msvc`
+
+Linux x64 は実行環境を判定して `-musl` または `-gnu` を選択します。
+
+## 開発時フォールバック
+
+OS 別パッケージが利用できない場合でも、ローカルビルドで実行できます。
+
+```bash
+cargo build --release
+```
+
+その後に:
+
+```bash
+i18next-turbo extract
+```
+
+## CI 運用の推奨
+
+- npm 依存キャッシュと Rust ターゲットキャッシュを分離する。
+- `package.json` と `package-lock.json` の整合性を保つ。
+- 必要に応じて `--config` で設定ファイルパスを明示して実行する。
+
+## 既知のレジストリ制約（2026-02-14 時点）
+
+執筆時点では `i18next-turbo-win32-x64-msvc` の publish が npm のスパム判定（`403`）で失敗する可能性があります。
+
+この場合の対応:
+
+1. [npm support](https://www.npmjs.com/support) に問い合わせる。
+2. `i18next-turbo-win32-x64-msvc` のパッケージ名審査解除を依頼する。
+3. 承認後に release publish を再実行する。
+
+それまで Windows ではソースビルド（`cargo build --release`）での利用を推奨します。

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,57 @@
+# Installation and Binary Resolution
+
+## Recommended
+
+```bash
+npm install --save-dev i18next-turbo
+```
+
+`i18next-turbo` uses platform packages via `optionalDependencies`.
+At runtime, `bin/cli.js` resolves the binary in this order:
+
+1. `CARGO_BIN_EXE_i18next_turbo` (Cargo test/dev environments)
+2. `I18NEXT_TURBO_BINARY` (manual override)
+3. Local builds (`target/debug`, `target/release`)
+4. Installed platform package
+
+## Platform Packages
+
+- `i18next-turbo-darwin-arm64`
+- `i18next-turbo-darwin-x64`
+- `i18next-turbo-linux-x64-gnu`
+- `i18next-turbo-linux-x64-musl`
+- `i18next-turbo-win32-x64-msvc`
+
+Linux x64 resolves `-musl` or `-gnu` depending on detected runtime.
+
+## Fallback for Development
+
+If platform packages are unavailable, local build still works:
+
+```bash
+cargo build --release
+```
+
+Then run:
+
+```bash
+i18next-turbo extract
+```
+
+## CI Recommendations
+
+- Cache npm dependencies and Rust target artifacts separately.
+- Keep `package.json` and `package-lock.json` aligned.
+- Run extraction/lint/check in CI with explicit config path when needed (`--config`).
+
+## Known Registry Limitation (as of February 14, 2026)
+
+At the time of writing, `i18next-turbo-win32-x64-msvc` may fail to publish due to npm spam-detection moderation (`403`).
+
+If this occurs:
+
+1. Open a support request at [npm support](https://www.npmjs.com/support).
+2. Ask for package-name moderation review for `i18next-turbo-win32-x64-msvc`.
+3. Re-run release publish after approval.
+
+Until then, Windows users should use source build fallback (`cargo build --release`).


### PR DESCRIPTION
## Summary
- simplify README.md into quick onboarding + command overview
- simplify README.ja.md with the same structure for consistency
- add dedicated install docs (`docs/installation.md`, `docs/installation.ja.md`) for platform package resolution, fallback paths, and current npm moderation caveat

## Why
- keep top-level README concise and globally understandable
- avoid duplication by moving operational details into focused docs
- clarify the OS-specific package behavior required for real-world usage

## Release
- no npm version bump in this PR (documentation-only change)
